### PR TITLE
Add Backstage catalog-info.yaml with owner

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: exa-data-eng-assessment
+  annotations:
+    github.com/project-slug: emisgroup/exa-data-eng-assessment
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/nightingale-admin


### PR DESCRIPTION
## Add Backstage catalog-info.yaml

This PR adds a `catalog-info.yaml` to register this repository in the [EMIS Developer Hub](https://github.com/emisgroup/emisx-dev-portal) and declare an owner.

**Please review:**
- `spec.owner` — confirm this is the correct team
- `spec.type` — update if this is not a `service` (e.g. `library`, `website`, `tool`)
- `spec.lifecycle` — update if not `production` (e.g. `experimental`, `deprecated`)

This PR was raised as part of a bulk Backstage ownership initiative.
